### PR TITLE
Enhanced Redis Cache AutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheProperties.java
@@ -32,7 +32,8 @@ import org.springframework.util.Assert;
  * @author Stephane Nicoll
  * @author Eddú Meléndez
  * @author Ryon Day
- * @since 1.3.0
+ * @author Anthony Lofton
+ * @since 2.2.1
  */
 @ConfigurationProperties(prefix = "spring.cache")
 public class CacheProperties {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheProperties.java
@@ -18,7 +18,9 @@ package org.springframework.boot.autoconfigure.cache;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.io.Resource;
@@ -56,7 +58,7 @@ public class CacheProperties {
 
 	private final JCache jcache = new JCache();
 
-	private final Redis redis = new Redis();
+	private final RedisGlobal redis = new RedisGlobal();
 
 	public CacheType getType() {
 		return this.type;
@@ -94,7 +96,7 @@ public class CacheProperties {
 		return this.jcache;
 	}
 
-	public Redis getRedis() {
+	public RedisGlobal getRedis() {
 		return this.redis;
 	}
 
@@ -287,6 +289,23 @@ public class CacheProperties {
 
 		public void setUseKeyPrefix(boolean useKeyPrefix) {
 			this.useKeyPrefix = useKeyPrefix;
+		}
+
+	}
+
+	public static class RedisGlobal extends Redis {
+
+		/**
+		 * Map of cache names to redis-specific cache properties.
+		 */
+		public Map<String, Redis> initialCacheConfigurations = new HashMap<>();
+
+		public Map<String, Redis> getInitialCacheConfigurations() {
+			return this.initialCacheConfigurations;
+		}
+
+		public void setInitialCacheConfigurations(Map<String, Redis> initialCacheConfigurations) {
+			this.initialCacheConfigurations = initialCacheConfigurations;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/RedisCacheConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/RedisCacheConfiguration.java
@@ -45,6 +45,7 @@ import org.springframework.data.redis.serializer.RedisSerializationContext.Seria
  * @author Stephane Nicoll
  * @author Mark Paluch
  * @author Ryon Day
+ * @author Anthony Lofton
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(RedisConnectionFactory.class)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
@@ -85,6 +85,7 @@ import static org.mockito.Mockito.verify;
  * @author Eddú Meléndez
  * @author Mark Paluch
  * @author Ryon Day
+ * @author Anthony Lofton
  */
 @ClassPathExclusions("hazelcast-client-*.jar")
 class CacheAutoConfigurationTests extends AbstractCacheAutoConfigurationTests {


### PR DESCRIPTION
Added new configuration in Redis cache for InitialCacheConfiguration.
This allows for configuration settings per cache name without needing to
add custom configuration code.
Added a test case to test the configuration is loaded.